### PR TITLE
Update climate.py

### DIFF
--- a/custom_components/hubitat/climate.py
+++ b/custom_components/hubitat/climate.py
@@ -237,6 +237,13 @@ class HubitatThermostat(HubitatEntity, ClimateEntity):
         return TEMP_CELSIUS
 
     @property
+    def precision(self) -> Optional[float]:
+        """Return current temperature precision when Farenheit and thermostat reports decimals."""
+        if self.temperature_unit == TEMP_FAHRENHEIT and "." in str(self.current_temperature):
+            return 0.1
+        return None
+
+    @property
     def unique_id(self) -> str:
         """Return a unique ID for this climate."""
         return f"{super().unique_id}::climate"

--- a/custom_components/hubitat/climate.py
+++ b/custom_components/hubitat/climate.py
@@ -43,7 +43,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT, PRECISION_TENTHS
 from homeassistant.core import HomeAssistant
 
 from .device import HubitatEntity
@@ -238,10 +238,8 @@ class HubitatThermostat(HubitatEntity, ClimateEntity):
 
     @property
     def precision(self) -> Optional[float]:
-        """Return current temperature precision when Farenheit and thermostat reports decimals."""
-        if self.temperature_unit == TEMP_FAHRENHEIT and "." in str(self.current_temperature):
-            return 0.1
-        return None
+        """Return current temperature precision in tenths."""
+        return PRECISION_TENTHS
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
Hubitat "Virtual Thermostats" may report decimal places for Current Temperature, but default precision for Fahrenheit reporting is Whole Number in HA. This change updates the precision to 'tenths'  for thermostats reporting decimals & Fahrenheit

