### PR TITLE
Use regex search() instead of match()

### DIFF
--- a/custom_components/hubitat/binary_sensor.py
+++ b/custom_components/hubitat/binary_sensor.py
@@ -173,7 +173,7 @@ def _get_contact_device_class(device: Device) -> str:
     name = device.name
 
     for matcher in _CONTACT_MATCHERS:
-        if matcher[0].match(name):
+        if matcher[0].search(name):
             return matcher[1]
 
     return DEVICE_CLASS_DOOR

--- a/custom_components/hubitat/light.py
+++ b/custom_components/hubitat/light.py
@@ -259,7 +259,7 @@ def is_light(device: Device, overrides: Optional[Dict[str, str]] = None) -> bool
 
     if is_definitely_light(device):
         return True
-    if CAP_SWITCH in device.capabilities and MATCH_LIGHT.match(device.name):
+    if CAP_SWITCH in device.capabilities and MATCH_LIGHT.search(device.name):
         return True
 
     # A Cover may also have a SwitchLevel capability that can be used to set

--- a/custom_components/hubitat/switch.py
+++ b/custom_components/hubitat/switch.py
@@ -56,7 +56,7 @@ class HubitatSwitch(HubitatEntity, SwitchEntity):
     @property
     def device_class(self) -> Optional[str]:
         """Return the class of this device, from component DEVICE_CLASSES."""
-        if _NAME_TEST.match(self._device.name):
+        if _NAME_TEST.search(self._device.name):
             return DEVICE_CLASS_SWITCH
         return DEVICE_CLASS_OUTLET
 


### PR DESCRIPTION
match() only matches at the beginning of ths tring. Use regex search() instead of match() so that it matches values not at the beginning of the name. e.g. will now match "Dining Room Switch".