### PR TITLE
Support binary_sensor device_type connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ The following device types are currently supported. The first level bullets are 
 - binary_sensor
   - acceleration
   - carbon monoxide
+  - connectivity
   - contact
   - moisture
   - motion
+  - presence
   - smoke
 - climate
   - thermostat

--- a/custom_components/hubitat/binary_sensor.py
+++ b/custom_components/hubitat/binary_sensor.py
@@ -39,9 +39,7 @@ _CONTACT_MATCHERS = (
     (re.compile("window", re.IGNORECASE), DEVICE_CLASS_WINDOW),
 )
 
-_PRESENCE_MATCHERS = (
-    (re.compile("presence", re.IGNORECASE), DEVICE_CLASS_PRESENCE),
-)
+_PRESENCE_MATCHERS = ((re.compile("presence", re.IGNORECASE), DEVICE_CLASS_PRESENCE),)
 
 
 class HubitatBinarySensor(HubitatEntity, BinarySensorEntity):
@@ -158,6 +156,7 @@ _SENSOR_ATTRS: Tuple[Tuple[str, Type[HubitatBinarySensor]], ...] = (
     (ATTR_WATER, HubitatMoistureSensor),
 )
 
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -166,6 +165,7 @@ async def async_setup_entry(
     """Initialize binary sensor entities."""
 
     for attr in _SENSOR_ATTRS:
+
         def is_sensor(
             device: Device, overrides: Optional[Dict[str, str]] = None
         ) -> bool:

--- a/custom_components/hubitat/binary_sensor.py
+++ b/custom_components/hubitat/binary_sensor.py
@@ -15,6 +15,7 @@ from hubitatmaker import (
 )
 
 from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_GARAGE_DOOR,
     DEVICE_CLASS_GAS,
@@ -36,6 +37,10 @@ from .types import EntityAdder
 _CONTACT_MATCHERS = (
     (re.compile("garage door", re.IGNORECASE), DEVICE_CLASS_GARAGE_DOOR),
     (re.compile("window", re.IGNORECASE), DEVICE_CLASS_WINDOW),
+)
+
+_PRESENCE_MATCHERS = (
+    (re.compile("presence", re.IGNORECASE), DEVICE_CLASS_PRESENCE),
 )
 
 
@@ -127,7 +132,11 @@ class HubitatPresenceSensor(HubitatBinarySensor):
 
     _active_state = "present"
     _attribute = ATTR_PRESENCE
-    _device_class = DEVICE_CLASS_PRESENCE
+
+    def __init__(self, hub: Hub, device: Device):
+        """Initialize a presence sensor."""
+        super().__init__(hub=hub, device=device)
+        self._device_class = _get_presence_device_class(device)
 
 
 class HubitatSmokeSensor(HubitatBinarySensor):
@@ -138,6 +147,7 @@ class HubitatSmokeSensor(HubitatBinarySensor):
     _device_class = DEVICE_CLASS_SMOKE
 
 
+# Presence is handled specially in async_setup_entry()
 _SENSOR_ATTRS: Tuple[Tuple[str, Type[HubitatBinarySensor]], ...] = (
     (ATTR_ACCELERATION, HubitatAccelerationSensor),
     (ATTR_CARBON_MONOXIDE, HubitatCoSensor),
@@ -148,16 +158,14 @@ _SENSOR_ATTRS: Tuple[Tuple[str, Type[HubitatBinarySensor]], ...] = (
     (ATTR_WATER, HubitatMoistureSensor),
 )
 
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: EntityAdder,
 ) -> None:
-    """Initialize light devices."""
+    """Initialize binary sensor entities."""
 
     for attr in _SENSOR_ATTRS:
-
         def is_sensor(
             device: Device, overrides: Optional[Dict[str, str]] = None
         ) -> bool:
@@ -177,3 +185,14 @@ def _get_contact_device_class(device: Device) -> str:
             return matcher[1]
 
     return DEVICE_CLASS_DOOR
+
+
+def _get_presence_device_class(device: Device) -> str:
+    """Guess the type of presence sensor from the device's label."""
+    name = device.name
+
+    for matcher in _PRESENCE_MATCHERS:
+        if matcher[0].search(name):
+            return matcher[1]
+
+    return DEVICE_CLASS_CONNECTIVITY


### PR DESCRIPTION
Support binary_sensor device_type connectivity. Often presence is used on devices to indicate connectivity in Hubitat. Determine presence vs connectivity depending on whether name contains "presence".