### PR TITLE
add https support to event listener server

### DIFF
--- a/custom_components/hubitat/config_flow.py
+++ b/custom_components/hubitat/config_flow.py
@@ -32,6 +32,8 @@ from .const import (
     CONF_DEVICES,
     CONF_SERVER_PORT,
     CONF_SERVER_URL,
+    CONF_SERVER_SSL_CERT,
+    CONF_SERVER_SSL_KEY,
     DOMAIN,
     STEP_OVERRIDE_LIGHTS,
     STEP_OVERRIDE_SWITCHES,
@@ -59,6 +61,8 @@ CONFIG_SCHEMA = vol.Schema(
         vol.Required(CONF_ACCESS_TOKEN): str,
         vol.Optional(CONF_SERVER_URL): str,
         vol.Optional(CONF_SERVER_PORT): int,
+        vol.Optional(CONF_SERVER_SSL_CERT): str,
+        vol.Optional(CONF_SERVER_SSL_KEY): str,
         vol.Optional(CONF_TEMPERATURE_UNIT, default=TEMP_F): vol.In([TEMP_F, TEMP_C]),
     }
 )
@@ -169,6 +173,8 @@ class HubitatOptionsFlow(OptionsFlow):
                     CONF_ACCESS_TOKEN: entry.data.get(CONF_ACCESS_TOKEN),
                     CONF_SERVER_PORT: user_input.get(CONF_SERVER_PORT),
                     CONF_SERVER_URL: user_input.get(CONF_SERVER_URL),
+                    CONF_SERVER_SSL_CERT: user_input.get(CONF_SERVER_SSL_CERT),
+                    CONF_SERVER_SSL_KEY: user_input.get(CONF_SERVER_SSL_KEY),
                 }
 
                 info = await _validate_input(check_input)
@@ -177,6 +183,8 @@ class HubitatOptionsFlow(OptionsFlow):
                 self.options[CONF_HOST] = user_input[CONF_HOST]
                 self.options[CONF_SERVER_PORT] = user_input.get(CONF_SERVER_PORT)
                 self.options[CONF_SERVER_URL] = user_input.get(CONF_SERVER_URL)
+                self.options[CONF_SERVER_SSL_CERT] = user_input.get(CONF_SERVER_SSL_CERT)
+                self.options[CONF_SERVER_SSL_KEY] = user_input.get(CONF_SERVER_SSL_KEY)
                 self.options[CONF_TEMPERATURE_UNIT] = user_input[CONF_TEMPERATURE_UNIT]
 
                 _LOGGER.debug("Moving to device removal step")
@@ -232,6 +240,22 @@ class HubitatOptionsFlow(OptionsFlow):
                             )
                         },
                     ): int,
+                    vol.Optional(
+                        CONF_SERVER_SSL_CERT,
+                        description={
+                            "suggested_value": entry.options.get(
+                                CONF_SERVER_SSL_CERT, entry.data.get(CONF_SERVER_SSL_CERT)
+                            )
+                        },
+                    ): str,
+                    vol.Optional(
+                        CONF_SERVER_SSL_KEY,
+                        description={
+                            "suggested_value": entry.options.get(
+                                CONF_SERVER_SSL_KEY, entry.data.get(CONF_SERVER_SSL_KEY)
+                            )
+                        },
+                    ): str,
                     vol.Optional(
                         CONF_TEMPERATURE_UNIT,
                         default=entry.options.get(

--- a/custom_components/hubitat/const.py
+++ b/custom_components/hubitat/const.py
@@ -53,6 +53,8 @@ CONF_DEVICE_TYPE_OVERRIDES = "device_type_overrides"
 CONF_SERVER_PORT = "server_port"
 CONF_SERVER_URL = "server_url"
 CONF_USE_SERVER_URL = "use_server_url"
+CONF_SERVER_SSL_CERT = "server_ssl_cert"
+CONF_SERVER_SSL_KEY = "server_ssl_key"
 
 CONF_BUTTON = "button"
 CONF_BUTTONS = ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12")

--- a/custom_components/hubitat/translations/en.json
+++ b/custom_components/hubitat/translations/en.json
@@ -19,6 +19,8 @@
                     "host": "Hub address",
                     "server_port": "Event server port (optional)",
                     "server_url": "Event server URL (optional)",
+                    "server_ssl_cert": "Event server SSL certificate (optional)",
+                    "server_ssl_key": "Event server SSL private key (optional)",
                     "temperature_unit": "Temperature units (optional)"
                 },
                 "description": "Provide the IP address or hostname of your Hubitat hub, along with the app ID of its Maker API instance. Optionally, provide a port number for the integration's event server to listen on, the units used for temperature sensors (F by default), and/or the URL that Hubitat should POST events to.",
@@ -84,6 +86,8 @@
                     "remove_devices": "Remove devices",
                     "server_port": "Event server port (optional)",
                     "server_url": "Event server URL (optional)",
+                    "server_ssl_cert": "Event server SSL certificate (optional)",
+                    "server_ssl_key": "Event server SSL private key (optional)",
                     "temperature_unit": "Temperature units (optional)"
                 },
                 "description": "Configure options for Hubitat. Note that changing the Maker API app ID will cause the integration to rediscover your devices.",


### PR DESCRIPTION
Hello, 

This is the custom_component counterpart to [https://github.com/jason0x43/hubitatmaker/pull/16](https://github.com/jason0x43/hubitatmaker/pull/16)

It allows the user to specify the path to the SSL certificate and private key files and run the event listener server with SSL. 
If either of the options are blank, the server will run without SSL. 