### PR TITLE
Changing the border between is_light and is_definitely_light.

### DIFF
--- a/custom_components/hubitat/light.py
+++ b/custom_components/hubitat/light.py
@@ -265,7 +265,7 @@ class HubitatLight(HubitatEntity, LightEntity):
         await self.send_command("off")
 
 
-LIGHT_CAPABILITIES = (CAP_COLOR_TEMP, CAP_COLOR_CONTROL, CAP_LIGHT)
+LIGHT_CAPABILITIES = (CAP_COLOR_TEMP, CAP_COLOR_CONTROL)
 
 # Ideally this would be multi-lingual
 MATCH_LIGHT = re.compile(
@@ -282,6 +282,8 @@ def is_light(device: Device, overrides: Optional[Dict[str, str]] = None) -> bool
     if is_definitely_light(device):
         return True
     if CAP_SWITCH in device.capabilities and MATCH_LIGHT.search(device.name):
+        return True
+    if CAP_LIGHT in device.capabilities:
         return True
 
     # A Cover may also have a SwitchLevel capability that can be used to set


### PR DESCRIPTION
Since there's some device (for example, ZB4003/43078 from enbrighten/Jasco) will be reported with light capability but it can be used as switch. Changing LIGHT_CAPABILITIES to capabilities which only useful for real light devices. And for the device which been reported with capability "Light" but not other light-related capabilities, they should not be considered as "definitely_light" since they can be used as switch in real world.
![image](https://user-images.githubusercontent.com/111748/196751177-204d5d0a-efe9-4a1f-952b-89b901f18bbb.png)
