### PR TITLE
Fix cover entity state

### DIFF
--- a/custom_components/hubitat/cover.py
+++ b/custom_components/hubitat/cover.py
@@ -89,7 +89,7 @@ class HubitatCover(HubitatEntity, CoverEntity):
     def is_opening(self) -> bool:
         """Return True if the cover is opening."""
         state = self.get_attr(self._attribute)
-        return state == DeviceState.PARTIALLY_OPEN
+        return state == DeviceState.OPENING
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""

--- a/custom_components/hubitat/cover.py
+++ b/custom_components/hubitat/cover.py
@@ -80,12 +80,6 @@ class HubitatCover(HubitatEntity, CoverEntity):
         return self.get_attr(self._attribute) == DeviceState.CLOSING
 
     @property
-    def is_open(self) -> bool:
-        """Return True if the cover is open."""
-        state = self.get_attr(self._attribute)
-        return state == DeviceState.OPEN or state == DeviceState.PARTIALLY_OPEN
-
-    @property
     def is_opening(self) -> bool:
         """Return True if the cover is opening."""
         state = self.get_attr(self._attribute)

--- a/custom_components/hubitat/cover.py
+++ b/custom_components/hubitat/cover.py
@@ -80,10 +80,16 @@ class HubitatCover(HubitatEntity, CoverEntity):
         return self.get_attr(self._attribute) == DeviceState.CLOSING
 
     @property
+    def is_open(self) -> bool:
+        """Return True if the cover is open."""
+        state = self.get_attr(self._attribute)
+        return state == DeviceState.OPEN or state == DeviceState.PARTIALLY_OPEN
+
+    @property
     def is_opening(self) -> bool:
         """Return True if the cover is opening."""
         state = self.get_attr(self._attribute)
-        return state == DeviceState.OPEN or state == DeviceState.PARTIALLY_OPEN
+        return state == DeviceState.PARTIALLY_OPEN
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""


### PR DESCRIPTION
In this commit https://github.com/jason0x43/hacs-hubitat/commit/dd2b4c0d6bbc9121cd8ddbc5d6916ffbe7eee1c2#diff-7e3eb469ea561d69ca0310f49362476a3b29e011f9f01ea8bb4b2d8610c614e2, the `is_open()` and `is_opening()` methods got kind of mangled. `is_open()` was deleted while `is_opening()` was changed to return true if the cover is open or opening. The result is that cover entities in Home Assistant reports "opening" when they are actually in the "open" state. This PR restores the original behavior. 