### PR TITLE
Add support for event entities

### DIFF
--- a/custom_components/hubitat/const.py
+++ b/custom_components/hubitat/const.py
@@ -41,6 +41,7 @@ class EventName(StrEnum):
     HELD = "held"
     DOUBLE_TAPPED = "double_tapped"
     PUSHED = "pushed"
+    RELEASED = "released"
     CODE_NAME = "code_name"
 
 
@@ -170,9 +171,3 @@ TRIGGER_CAPABILITIES = {
         H_CONF_UNLOCKED_WITH_CODE,
     ),
 }
-
-# Hubitat attributes that should be emitted as HA events
-_TRIGGER_ATTRS = tuple([v.attr for v in TRIGGER_CAPABILITIES.values()])
-# A mapping from Hubitat attribute names to the attribute names that should be
-# used for HA events
-_TRIGGER_ATTR_MAP = {v.attr: v.event for v in TRIGGER_CAPABILITIES.values()}

--- a/custom_components/hubitat/const.py
+++ b/custom_components/hubitat/const.py
@@ -78,6 +78,7 @@ Platform = Literal[
     "binary_sensor",
     "climate",
     "cover",
+    "event",
     "light",
     "lock",
     "select",
@@ -169,3 +170,9 @@ TRIGGER_CAPABILITIES = {
         H_CONF_UNLOCKED_WITH_CODE,
     ),
 }
+
+# Hubitat attributes that should be emitted as HA events
+_TRIGGER_ATTRS = tuple([v.attr for v in TRIGGER_CAPABILITIES.values()])
+# A mapping from Hubitat attribute names to the attribute names that should be
+# used for HA events
+_TRIGGER_ATTR_MAP = {v.attr: v.event for v in TRIGGER_CAPABILITIES.values()}

--- a/custom_components/hubitat/event.py
+++ b/custom_components/hubitat/event.py
@@ -1,0 +1,97 @@
+"""Hubitat event entities."""
+
+from logging import getLogger
+from typing import Unpack
+
+from homeassistant.components.event import (
+    EventDeviceClass,
+    EventEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    _TRIGGER_ATTRS,
+    _TRIGGER_ATTR_MAP,
+)
+from .device import HubitatEntity, HubitatEntityArgs
+from .hub import get_hub
+from .hubitatmaker import DeviceAttribute, Event
+from .types import EntityAdder
+
+_LOGGER = getLogger(__name__)
+
+
+class HubitatButtonEvent(HubitatEntity, EventEntity):
+    """Representation of an Hubitat button event"""
+
+    _button_id: str
+
+    def __init__(self, button_id: str, **kwargs: Unpack[HubitatEntityArgs]):
+        """Initialize a hubitat button event entity"""
+        HubitatEntity.__init__(self, device_class=EventDeviceClass.BUTTON, **kwargs)
+        EventEntity.__init__(self)
+
+        self._button_id = button_id
+        self._attr_unique_id = f"{super().unique_id}::button_event::{self._button_id}"
+        self._attr_event_types = self.get_event_types()
+
+    @property
+    def name(self) -> str:
+        """Return the display name for this button event entity."""
+        return f"{super().name} button {self._button_id}".title()
+
+    def handle_event(self, event: Event) -> None:
+        if event.attribute not in _TRIGGER_ATTRS:
+            return
+
+        if event.value != self._button_id:
+            return
+
+        event_type = _TRIGGER_ATTR_MAP[event.attribute]
+        self._trigger_event(event_type)
+        self.async_write_ha_state()
+
+    def get_event_types(self) -> list[str]:
+        event_attrs = filter(
+            lambda attr: attr in self._device.attributes,
+            _TRIGGER_ATTRS
+        )
+        event_types = map(
+            lambda attr: _TRIGGER_ATTR_MAP[attr],
+            list(event_attrs)
+        )
+        return list(event_types)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: EntityAdder,
+) -> None:
+    """Initialize hubitat button events entities."""
+    hub = get_hub(hass, config_entry.entry_id)
+
+    event_entities = []
+    for id in hub.devices:
+        device = hub.devices[id]
+        if DeviceAttribute.NUM_BUTTONS not in device.attributes:
+            continue
+
+        num_buttons = device.attributes[DeviceAttribute.NUM_BUTTONS].int_value
+        if num_buttons is None:
+            continue
+
+        for i in range(1, num_buttons + 1):
+            event_entities.append(
+                HubitatButtonEvent(
+                    button_id=str(i),
+                    hub=hub,
+                    device=device
+                )
+            )
+
+    if len(event_entities) > 0:
+        hub.add_entities(event_entities)
+        async_add_entities(event_entities)
+        _LOGGER.debug(f"Added button event entities: {event_entities}")

--- a/custom_components/hubitat/event.py
+++ b/custom_components/hubitat/event.py
@@ -42,6 +42,9 @@ class HubitatButtonEvent(HubitatEntity, EventEntity):
         return f"{super().name} button {self._button_id}".title()
 
     def handle_event(self, event: Event) -> None:
+        if self.is_disabled:
+            return
+
         if event.attribute not in _TRIGGER_ATTRS:
             return
 

--- a/custom_components/hubitat/hub.py
+++ b/custom_components/hubitat/hub.py
@@ -32,8 +32,7 @@ from .const import (
     H_CONF_SERVER_URL,
     PLATFORMS,
     TEMP_F,
-    _TRIGGER_ATTRS,
-    _TRIGGER_ATTR_MAP,
+    TRIGGER_CAPABILITIES,
 )
 from .hubitatmaker import (
     Device,
@@ -49,6 +48,12 @@ Listener = Callable[[Event], None]
 
 HUB_DEVICE_NAME = "Hub"
 HUB_NAME = "Hubitat Elevation"
+
+# Hubitat attributes that should be emitted as HA events
+_TRIGGER_ATTRS = tuple([v.attr for v in TRIGGER_CAPABILITIES.values()])
+# A mapping from Hubitat attribute names to the attribute names that should be
+# used for HA events
+_TRIGGER_ATTR_MAP = {v.attr: v.event for v in TRIGGER_CAPABILITIES.values()}
 
 E = TypeVar("E", bound=UpdateableEntity)
 M = TypeVar("M", bound=Removable)

--- a/custom_components/hubitat/hub.py
+++ b/custom_components/hubitat/hub.py
@@ -32,7 +32,8 @@ from .const import (
     H_CONF_SERVER_URL,
     PLATFORMS,
     TEMP_F,
-    TRIGGER_CAPABILITIES,
+    _TRIGGER_ATTRS,
+    _TRIGGER_ATTR_MAP,
 )
 from .hubitatmaker import (
     Device,
@@ -48,13 +49,6 @@ Listener = Callable[[Event], None]
 
 HUB_DEVICE_NAME = "Hub"
 HUB_NAME = "Hubitat Elevation"
-
-
-# Hubitat attributes that should be emitted as HA events
-_TRIGGER_ATTRS = tuple([v.attr for v in TRIGGER_CAPABILITIES.values()])
-# A mapping from Hubitat attribute names to the attribute names that should be
-# used for HA events
-_TRIGGER_ATTR_MAP = {v.attr: v.event for v in TRIGGER_CAPABILITIES.values()}
 
 E = TypeVar("E", bound=UpdateableEntity)
 M = TypeVar("M", bound=Removable)


### PR DESCRIPTION
This PR creates an event entity for every button on a device. The event entities will be triggered when the corresponding button is triggered (pressed, doubleTapped, held etc.).