### PR TITLE
Identify hub in log

### DIFF
--- a/custom_components/hubitat/hubitatmaker/hub.py
+++ b/custom_components/hubitat/hubitatmaker/hub.py
@@ -381,22 +381,34 @@ class Hub:
     ) -> None:
         """Update a device attribute value."""
         _LOGGER.debug(
-            "Updating %s of %s to %s (%s)",
+            "Setting %s to %s (%s) for device %s from api %s at hub %s",
             attr_name,
-            device_id,
             value,
             value_unit,
+            device_id,
+            self.app_id,
+            self.host,
         )
         try:
             dev = self._devices[device_id]
         except KeyError:
-            _LOGGER.warning("Tried to update unknown device %s", device_id)
+            _LOGGER.warning(
+                "Tried to update unknown device %s from api %s at hub %s",
+                device_id,
+                self.app_id,
+                self.host,
+            )
             return
 
         try:
             dev.update_attr(attr_name, value, value_unit)
         except KeyError:
-            _LOGGER.warning("Tried to update unknown attribute %s", attr_name)
+            _LOGGER.warning(
+                "Tried to update unknown attribute %s from api %s at hub %s",
+                attr_name,
+                self.app_id,
+                self.host,
+            )
 
     async def _load_device(self, device_id: str, force_refresh: bool = False) -> None:
         """Return full info for a specific device."""

--- a/custom_components/hubitat/manifest.json
+++ b/custom_components/hubitat/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../manifest-schema.json",
-  "version": "0.10.0-pre2",
+  "version": "0.10.0",
   "domain": "hubitat",
   "name": "Hubitat",
   "config_flow": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hubitat"
-version = "0.10.0-pre2"
+version = "0.10.0"
 description = "A Hubitat integration for Home Assistant"
 authors = [{ name = "Jason Cheatham", email = "jason@jasoncheatham.com" }]
 requires-python = ">=3.13.2"


### PR DESCRIPTION
In "unknown X" warnings, include the hub URL and app ID to make identifying the device easier.

Resolves #330 