### PR TITLE
Fix missing device classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@ This is a Home Assistant integration for Hubitat hubs that allows Hubitat device
 
 ## Development Commands
 
+### Requirements
+
+- Python >=3.13.2
+- Home Assistant >=2025.4.0
+
 ### Development Setup
 
 - Initialize development environment: `uv sync`
@@ -27,6 +32,16 @@ This is a Home Assistant integration for Hubitat hubs that allows Hubitat device
 
 - Install dependencies: `uv sync`
 - Add development dependency: `uv add --dev <package>`
+
+### Local Development
+
+- Run integration with local Home Assistant: `./home_assistant start`
+- Pre-commit hooks run automatically on commit (ruff + type checking)
+- Install pre-commit manually: `uv run pre-commit install`
+
+### Publishing
+
+- Create new release: `python scripts/publish.py` (prompts for version, creates tag, pushes)
 
 ## Architecture
 
@@ -55,14 +70,16 @@ This is a Home Assistant integration for Hubitat hubs that allows Hubitat device
 
 The integration supports multiple Home Assistant platforms, each in its own file:
 
+- `alarm_control_panel.py` - Home security systems
 - `binary_sensor.py` - Motion, contact, smoke, etc.
 - `climate.py` - Thermostats and HVAC controls
+- `cover.py` - Garage doors, window shades
+- `event.py` - Event entities
+- `fan.py` - Fan controls
 - `light.py` - Lights with various capabilities (dimming, color, etc.)
 - `lock.py` - Door locks and keypads
 - `sensor.py` - Temperature, humidity, battery, etc.
 - `switch.py` - Basic on/off switches
-- `cover.py` - Garage doors, window shades
-- `fan.py` - Fan controls
 - `valve.py` - Water valves
 
 ### Configuration Flow
@@ -98,6 +115,11 @@ The event server is automatically configured in the Maker API instance to push d
 
 ## Development Notes
 
+### Git Workflow
+
+- Main branch: `master` (not `main`)
+- PRs should target `master`
+
 ### Device Capability Mapping
 
 - Devices are mapped to HA platforms based on Hubitat capabilities
@@ -116,6 +138,11 @@ The event server is automatically configured in the Maker API instance to push d
 - Unit tests focus on device mapping and capability detection
 - Mock Hubitat API responses for predictable testing
 - Integration tests validate the full setup flow
+
+### Testing Gotchas
+
+- **Device classes**: Device class assignment is based on capabilities. When adding new device types, verify `device_class` is set correctly (see tests/test_*.py for patterns).
+- **Mock responses**: Mock data in `tests/hubitatmaker/` should match real Hubitat API responses for accuracy.
 
 ### Dependencies
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,17 +33,20 @@ This is a Home Assistant integration for Hubitat hubs that allows Hubitat device
 ### Core Components
 
 **Integration Entry Point** (`custom_components/hubitat/__init__.py`):
+
 - Manages the lifecycle of the integration
 - Handles config entry setup/unload
 - Registers services and event listeners
 
 **Hub Management** (`custom_components/hubitat/hub.py`):
+
 - Central hub class that manages connection to Hubitat
 - Handles device discovery and registration
 - Manages the event server for real-time updates
 - Coordinates between Home Assistant and Hubitat devices
 
 **Hubitat Maker Library** (`custom_components/hubitat/hubitatmaker/`):
+
 - Low-level communication with Hubitat's Maker API
 - Device modeling and event handling
 - HTTP server for receiving device events from Hubitat
@@ -51,6 +54,7 @@ This is a Home Assistant integration for Hubitat hubs that allows Hubitat device
 ### Device Platforms
 
 The integration supports multiple Home Assistant platforms, each in its own file:
+
 - `binary_sensor.py` - Motion, contact, smoke, etc.
 - `climate.py` - Thermostats and HVAC controls
 - `light.py` - Lights with various capabilities (dimming, color, etc.)
@@ -64,6 +68,7 @@ The integration supports multiple Home Assistant platforms, each in its own file
 ### Configuration Flow
 
 **Config Flow** (`custom_components/hubitat/config_flow.py`):
+
 - Handles initial setup wizard
 - Device discovery and selection
 - SSL configuration for event server
@@ -72,6 +77,7 @@ The integration supports multiple Home Assistant platforms, each in its own file
 ### Event System
 
 The integration uses a bi-directional communication model:
+
 1. **Control**: Home Assistant → Hubitat via Maker API HTTP requests
 2. **Updates**: Hubitat → Home Assistant via HTTP POST to local event server
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/custom_components/hubitat/binary_sensor.py
+++ b/custom_components/hubitat/binary_sensor.py
@@ -52,9 +52,9 @@ class HubitatBinarySensor(BinarySensorEntity, HubitatEntity):
         device_class: BinarySensorDeviceClass | None = None,
         **kwargs: Unpack[HubitatEntityArgs],
     ):
-        HubitatEntity.__init__(self, device_class=device_class, **kwargs)
+        HubitatEntity.__init__(self, **kwargs)
         BinarySensorEntity.__init__(self)
-
+        self._attr_device_class = device_class
         self._attribute = attribute
         self._active_state = active_state
         self._attr_unique_id: str | None = (

--- a/custom_components/hubitat/cover.py
+++ b/custom_components/hubitat/cover.py
@@ -42,9 +42,9 @@ class HubitatCover(CoverEntity, HubitatEntity):
         device_class: CoverDeviceClass | None = None,
         **kwargs: Unpack[HubitatEntityArgs],
     ):
-        HubitatEntity.__init__(self, device_class=device_class, **kwargs)
+        HubitatEntity.__init__(self, **kwargs)
         CoverEntity.__init__(self)
-
+        self._attr_device_class = device_class
         self._attribute = attribute
         self._attr_supported_features = features
         self._attr_unique_id = f"{super().unique_id}::cover::{attribute}"

--- a/custom_components/hubitat/event.py
+++ b/custom_components/hubitat/event.py
@@ -33,9 +33,9 @@ class HubitatButtonEventEntity(EventEntity, HubitatEntity):
 
     def __init__(self, button_id: str, **kwargs: Unpack[HubitatEntityArgs]):
         """Initialize a hubitat button event entity"""
-        HubitatEntity.__init__(self, device_class=EventDeviceClass.BUTTON, **kwargs)
+        HubitatEntity.__init__(self, **kwargs)
         EventEntity.__init__(self)
-
+        self._attr_device_class = EventDeviceClass.BUTTON
         self._button_id = button_id
         self._attr_unique_id: str | None = (
             f"{super().unique_id}::button_event::{self._button_id}"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -7,10 +7,17 @@ from custom_components.hubitat.binary_sensor import (
     HubitatBinarySensor,
     HubitatContactSensor,
     HubitatCoSensor,
+    HubitatHeatSensor,
     HubitatMoistureSensor,
     HubitatMotionSensor,
+    HubitatNaturalGasSensor,
+    HubitatNetworkStatusSensor,
     HubitatPresenceSensor,
+    HubitatShockSensor,
     HubitatSmokeSensor,
+    HubitatSoundSensor,
+    HubitatTamperSensor,
+    HubitatValveSensor,
 )
 from custom_components.hubitat.hubitatmaker.const import DeviceAttribute
 from custom_components.hubitat.hubitatmaker.types import Attribute
@@ -50,6 +57,7 @@ def test_binary_sensor_init():
     assert sensor._attribute == DeviceAttribute.CONTACT
     assert sensor._active_state == "open"
     assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.DOOR
 
 
 def test_binary_sensor_inactive_state():
@@ -83,6 +91,7 @@ def test_binary_sensor_inactive_state():
     )
 
     assert sensor.is_on is False
+    assert sensor.device_class == BinarySensorDeviceClass.DOOR
 
 
 def test_binary_sensor_device_attrs():
@@ -142,6 +151,7 @@ def test_acceleration_sensor():
     sensor = HubitatAccelerationSensor(hub=hub, device=device)
 
     assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.MOVING
 
 
 def test_co_sensor():
@@ -169,6 +179,7 @@ def test_co_sensor():
     sensor = HubitatCoSensor(hub=hub, device=device)
 
     assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.GAS
 
 
 def test_contact_sensor_door():
@@ -196,6 +207,7 @@ def test_contact_sensor_door():
     sensor = HubitatContactSensor(hub=hub, device=device)
 
     assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.DOOR
 
 
 def test_contact_sensor_window():
@@ -223,6 +235,7 @@ def test_contact_sensor_window():
     sensor = HubitatContactSensor(hub=hub, device=device)
 
     assert sensor.is_on is False
+    assert sensor.device_class == BinarySensorDeviceClass.WINDOW
 
 
 def test_moisture_sensor():
@@ -250,6 +263,7 @@ def test_moisture_sensor():
     sensor = HubitatMoistureSensor(hub=hub, device=device)
 
     assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.MOISTURE
 
 
 def test_motion_sensor():
@@ -277,6 +291,7 @@ def test_motion_sensor():
     sensor = HubitatMotionSensor(hub=hub, device=device)
 
     assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.MOTION
 
 
 def test_presence_sensor():
@@ -304,6 +319,7 @@ def test_presence_sensor():
     sensor = HubitatPresenceSensor(hub=hub, device=device)
 
     assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.PRESENCE
 
 
 def test_smoke_sensor():
@@ -331,3 +347,200 @@ def test_smoke_sensor():
     sensor = HubitatSmokeSensor(hub=hub, device=device)
 
     assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.SMOKE
+
+
+def test_natural_gas_sensor():
+    """Test that a natural gas sensor can be initialized."""
+    hub = Mock()
+    hub.configure_mock(token="test-token")
+
+    device = Mock()
+    device.configure_mock(
+        id="test-id",
+        name="Test Natural Gas",
+        label="Test Natural Gas",
+        attributes={
+            DeviceAttribute.NATURAL_GAS: Attribute(
+                {
+                    "name": DeviceAttribute.NATURAL_GAS,
+                    "currentValue": "detected",
+                    "dataType": "STRING",
+                    "unit": None,
+                }
+            )
+        },
+    )
+
+    sensor = HubitatNaturalGasSensor(hub=hub, device=device)
+
+    assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.GAS
+
+
+def test_network_status_sensor():
+    """Test that a network status sensor can be initialized."""
+    hub = Mock()
+    hub.configure_mock(token="test-token")
+
+    device = Mock()
+    device.configure_mock(
+        id="test-id",
+        name="Test Network",
+        label="Test Network",
+        attributes={
+            DeviceAttribute.NETWORK_STATUS: Attribute(
+                {
+                    "name": DeviceAttribute.NETWORK_STATUS,
+                    "currentValue": "online",
+                    "dataType": "STRING",
+                    "unit": None,
+                }
+            )
+        },
+    )
+
+    sensor = HubitatNetworkStatusSensor(hub=hub, device=device)
+
+    assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.CONNECTIVITY
+
+
+def test_sound_sensor():
+    """Test that a sound sensor can be initialized."""
+    hub = Mock()
+    hub.configure_mock(token="test-token")
+
+    device = Mock()
+    device.configure_mock(
+        id="test-id",
+        name="Test Sound",
+        label="Test Sound",
+        attributes={
+            DeviceAttribute.SOUND: Attribute(
+                {
+                    "name": DeviceAttribute.SOUND,
+                    "currentValue": "detected",
+                    "dataType": "STRING",
+                    "unit": None,
+                }
+            )
+        },
+    )
+
+    sensor = HubitatSoundSensor(hub=hub, device=device)
+
+    assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.SOUND
+
+
+def test_tamper_sensor():
+    """Test that a tamper sensor can be initialized."""
+    hub = Mock()
+    hub.configure_mock(token="test-token")
+
+    device = Mock()
+    device.configure_mock(
+        id="test-id",
+        name="Test Tamper",
+        label="Test Tamper",
+        attributes={
+            DeviceAttribute.TAMPER: Attribute(
+                {
+                    "name": DeviceAttribute.TAMPER,
+                    "currentValue": "detected",
+                    "dataType": "STRING",
+                    "unit": None,
+                }
+            )
+        },
+    )
+
+    sensor = HubitatTamperSensor(hub=hub, device=device)
+
+    assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.TAMPER
+
+
+def test_shock_sensor():
+    """Test that a shock sensor can be initialized."""
+    hub = Mock()
+    hub.configure_mock(token="test-token")
+
+    device = Mock()
+    device.configure_mock(
+        id="test-id",
+        name="Test Shock",
+        label="Test Shock",
+        attributes={
+            DeviceAttribute.SHOCK: Attribute(
+                {
+                    "name": DeviceAttribute.SHOCK,
+                    "currentValue": "detected",
+                    "dataType": "STRING",
+                    "unit": None,
+                }
+            )
+        },
+    )
+
+    sensor = HubitatShockSensor(hub=hub, device=device)
+
+    assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.VIBRATION
+
+
+def test_heat_sensor():
+    """Test that a heat sensor can be initialized."""
+    hub = Mock()
+    hub.configure_mock(token="test-token")
+
+    device = Mock()
+    device.configure_mock(
+        id="test-id",
+        name="Test Heat",
+        label="Test Heat",
+        attributes={
+            DeviceAttribute.HEAT_ALARM: Attribute(
+                {
+                    "name": DeviceAttribute.HEAT_ALARM,
+                    "currentValue": "overheat",
+                    "dataType": "STRING",
+                    "unit": None,
+                }
+            )
+        },
+    )
+
+    sensor = HubitatHeatSensor(hub=hub, device=device)
+
+    assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.HEAT
+
+
+def test_valve_sensor():
+    """Test that a valve sensor can be initialized."""
+    hub = Mock()
+    hub.configure_mock(token="test-token")
+
+    device = Mock()
+    device.configure_mock(
+        id="test-id",
+        name="Test Valve",
+        label="Test Valve",
+        attributes={
+            DeviceAttribute.VALVE: Attribute(
+                {
+                    "name": DeviceAttribute.VALVE,
+                    "currentValue": "open",
+                    "dataType": "STRING",
+                    "unit": None,
+                }
+            )
+        },
+    )
+
+    sensor = HubitatValveSensor(hub=hub, device=device)
+
+    assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.OPENING

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -51,6 +51,7 @@ def test_cover_init():
 
     assert cover.is_closed is True
     assert cover.current_cover_position == 0
+    assert cover.device_class == CoverDeviceClass.DOOR
 
 
 def test_cover_open():
@@ -272,6 +273,7 @@ def test_garage_door_control():
         CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
     )
     assert cover.is_closed is True
+    assert cover.device_class == CoverDeviceClass.GARAGE
 
 
 def test_window_shade():
@@ -312,6 +314,7 @@ def test_window_shade():
         | CoverEntityFeature.SET_POSITION
     )
     assert cover.is_closed is False
+    assert cover.device_class == CoverDeviceClass.SHADE
 
 
 def test_window_blind():
@@ -344,6 +347,7 @@ def test_window_blind():
         | CoverEntityFeature.SET_POSITION
     )
     assert cover.is_closed is True
+    assert cover.device_class == CoverDeviceClass.BLIND
 
 
 def test_cover_device_attrs():

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,69 @@
+from unittest.mock import Mock
+
+from custom_components.hubitat.event import HubitatButtonEventEntity
+from custom_components.hubitat.hubitatmaker.const import DeviceAttribute
+from custom_components.hubitat.hubitatmaker.types import Attribute
+from homeassistant.components.event import EventDeviceClass
+
+
+def test_button_event_entity_init():
+    """Test that a button event entity can be initialized."""
+    hub = Mock()
+    hub.configure_mock(token="test-token")
+
+    device = Mock()
+    device.configure_mock(
+        id="test-id",
+        name="Test Button",
+        label="Test Button",
+        attributes={
+            DeviceAttribute.PUSHED: Attribute(
+                {
+                    "name": DeviceAttribute.PUSHED,
+                    "currentValue": "1",
+                    "dataType": "STRING",
+                    "unit": None,
+                }
+            ),
+            DeviceAttribute.HELD: Attribute(
+                {
+                    "name": DeviceAttribute.HELD,
+                    "currentValue": "1",
+                    "dataType": "STRING",
+                    "unit": None,
+                }
+            ),
+        },
+    )
+
+    entity = HubitatButtonEventEntity(button_id="1", hub=hub, device=device)
+
+    assert entity._button_id == "1"
+    assert entity.device_class == EventDeviceClass.BUTTON
+
+
+def test_button_event_entity_device_class():
+    """Test that button event entity has correct device class."""
+    hub = Mock()
+    hub.configure_mock(token="test-token")
+
+    device = Mock()
+    device.configure_mock(
+        id="test-id",
+        name="Test Button",
+        label="Test Button",
+        attributes={
+            DeviceAttribute.PUSHED: Attribute(
+                {
+                    "name": DeviceAttribute.PUSHED,
+                    "currentValue": "2",
+                    "dataType": "STRING",
+                    "unit": None,
+                }
+            ),
+        },
+    )
+
+    entity = HubitatButtonEventEntity(button_id="2", hub=hub, device=device)
+
+    assert entity.device_class == EventDeviceClass.BUTTON


### PR DESCRIPTION
An update in v0.10.0 caused certain device types to longer set device classes. Restore this functionality.

Resolves #334 