### PR TITLE
Add a hub status sensor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/codebook.toml
+++ b/codebook.toml
@@ -1,5 +1,6 @@
 words = [
     "ereg",
     "hass",
+    "hsm",
     "hubitat",
 ]

--- a/custom_components/hubitat/__init__.py
+++ b/custom_components/hubitat/__init__.py
@@ -112,19 +112,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                         _ = hass.config_entries.async_update_entry(
                             config_entry, title=f"Hubitat ({hub.id})"
                         )
-
-                    hass.states.async_set(
-                        hub.entity_id,
-                        "connected",
-                        hub.get_state_attributes(),
-                    )
                 except (asyncio.TimeoutError, ConnectionError) as e:
                     _LOGGER.debug("Reconnection attempt failed: %s", e)
-                    hass.states.async_set(
-                        hub.entity_id,
-                        "unavailable",
-                        hub.get_state_attributes(),
-                    )
+                    hub.set_connected(False)
 
         # Retry immediately once, then periodically
         _ = hass.async_create_task(retry_connection())

--- a/custom_components/hubitat/__init__.py
+++ b/custom_components/hubitat/__init__.py
@@ -17,10 +17,11 @@ from homeassistant.const import CONF_ACCESS_TOKEN, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import DOMAIN, H_CONF_HUB_ID, H_CONF_HUBITAT_EVENT, PLATFORMS
+from .const import DOMAIN, H_CONF_HUB_ID, H_CONF_HUBITAT_EVENT, PLATFORMS, Platform
 from .hub import Hub, get_domain_data, get_hub
 
 _LOGGER = getLogger(__name__)
+_HUB_STATUS_PLATFORMS: tuple[Platform, ...] = ("binary_sensor",)
 
 # Time to attempt initial hub connection during startup
 STARTUP_CONNECT_TIMEOUT = 60  # seconds
@@ -75,6 +76,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     # First create an offline hub to get a HubitatHub instance we can cleanup
     # if the connection attempt times out
     hub = await Hub.create_offline(hass, config_entry, len(domain_data) + 1)
+    await hass.config_entries.async_forward_entry_setups(
+        config_entry, _HUB_STATUS_PLATFORMS
+    )
+    hub.mark_platforms_setup(_HUB_STATUS_PLATFORMS)
 
     try:
         # Try to connect with timeout
@@ -151,16 +156,19 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 
     async_remove_services(hass, config_entry)
 
+    hub = get_hub(hass, config_entry.entry_id)
+    platforms_to_unload = tuple(
+        p for p in PLATFORMS if p not in hub.get_unsetup_platforms()
+    )
+
     unload_ok = all(
         await asyncio.gather(
             *[
                 hass.config_entries.async_forward_entry_unload(config_entry, component)
-                for component in PLATFORMS
+                for component in platforms_to_unload
             ]
         )
     )
-
-    hub = get_hub(hass, config_entry.entry_id)
 
     hub.stop()
     _LOGGER.debug(f"Stopped event server for {config_entry.entry_id}")

--- a/custom_components/hubitat/binary_sensor.py
+++ b/custom_components/hubitat/binary_sensor.py
@@ -84,7 +84,7 @@ class HubitatHubConnectionBinarySensor(BinarySensorEntity, HubitatEntity):
     _connection_listener: Callable[[bool], None] | None
 
     def __init__(self, **kwargs: Unpack[HubitatEntityArgs]):
-        HubitatEntity.__init__(self, **kwargs)
+        HubitatEntity.__init__(self, listen_for_device_events=False, **kwargs)
         BinarySensorEntity.__init__(self)
 
         self._attr_unique_id = f"{self._hub.id}::binary_sensor::hub_status"

--- a/custom_components/hubitat/binary_sensor.py
+++ b/custom_components/hubitat/binary_sensor.py
@@ -333,19 +333,41 @@ async def async_setup_entry(
     hub.add_entities(hub_entities)
     async_add_entities(hub_entities)
 
-    for attr in _SENSOR_ATTRS:
+    sensors_added = False
 
-        def is_sensor(device: Device, _overrides: dict[str, str] | None = None) -> bool:
-            return attr[0] in device.attributes
+    def add_device_sensors() -> None:
+        nonlocal sensors_added
+        if sensors_added:
+            return
+        sensors_added = True
 
-        _ = create_and_add_entities(
-            hass,
-            config_entry,
-            async_add_entities,
-            "binary_sensor",
-            attr[1],
-            is_sensor,
-        )
+        for attr in _SENSOR_ATTRS:
+
+            def is_sensor(
+                device: Device, _overrides: dict[str, str] | None = None
+            ) -> bool:
+                return attr[0] in device.attributes
+
+            _ = create_and_add_entities(
+                hass,
+                config_entry,
+                async_add_entities,
+                "binary_sensor",
+                attr[1],
+                is_sensor,
+            )
+
+    if hub.is_connected:
+        add_device_sensors()
+    else:
+
+        @callback
+        def handle_connection_change(connected: bool) -> None:
+            if connected:
+                add_device_sensors()
+                hub.remove_connection_listener(handle_connection_change)
+
+        hub.add_connection_listener(handle_connection_change)
 
 
 def _get_contact_info(device: Device) -> ContactInfo:

--- a/custom_components/hubitat/binary_sensor.py
+++ b/custom_components/hubitat/binary_sensor.py
@@ -3,7 +3,7 @@
 import re
 from dataclasses import dataclass
 from re import Pattern
-from typing import TYPE_CHECKING, Callable, Unpack, override
+from typing import TYPE_CHECKING, Any, Callable, Unpack, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -121,14 +121,14 @@ class HubitatHubConnectionBinarySensor(BinarySensorEntity, HubitatEntity):
 
     @property
     @override
-    def extra_state_attributes(self) -> dict[str, str | bool] | None:
+    def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return hub metadata that was previously in the legacy hub state."""
         return {
             CONF_ID: f"{self._hub.host}::{self._hub.app_id}",
             CONF_HOST: self._hub.host,
             ATTR_HIDDEN: True,
             CONF_TEMPERATURE_UNIT: self._hub.temperature_unit,
-            "connection_state": "connected" if self.is_on else "unavailable",
+            "connection_state": "connected" if self.is_on else "disconnected",
         }
 
 

--- a/custom_components/hubitat/binary_sensor.py
+++ b/custom_components/hubitat/binary_sensor.py
@@ -3,18 +3,20 @@
 import re
 from dataclasses import dataclass
 from re import Pattern
-from typing import TYPE_CHECKING, Unpack, override
+from typing import TYPE_CHECKING, Callable, Unpack, override
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.const import ATTR_HIDDEN, CONF_HOST, CONF_ID, CONF_TEMPERATURE_UNIT
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .device import HubitatEntity, HubitatEntityArgs
 from .entities import create_and_add_entities
+from .hub import get_hub
 from .hubitatmaker import Device, DeviceAttribute
 
 
@@ -74,6 +76,60 @@ class HubitatBinarySensor(BinarySensorEntity, HubitatEntity):
     def device_attrs(self) -> tuple[DeviceAttribute, ...] | None:
         """Return this entity's associated attributes"""
         return (self._attribute,)
+
+
+class HubitatHubConnectionBinarySensor(BinarySensorEntity, HubitatEntity):
+    """A binary sensor for Hubitat hub connection status."""
+
+    _connection_listener: Callable[[bool], None] | None
+
+    def __init__(self, **kwargs: Unpack[HubitatEntityArgs]):
+        HubitatEntity.__init__(self, **kwargs)
+        BinarySensorEntity.__init__(self)
+
+        self._attr_unique_id = f"{self._hub.id}::binary_sensor::hub_status"
+        self._attr_name = f"{super().name} Status".title()
+        self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+        self._connection_listener = None
+        self.load_state()
+
+    @override
+    def load_state(self) -> None:
+        """Load current connection state from the hub."""
+        self._attr_is_on = self._hub.is_connected
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Listen for hub connection status changes."""
+        await super().async_added_to_hass()
+
+        @callback
+        def handle_connection_change(connected: bool) -> None:
+            self._attr_is_on = connected
+            self.async_schedule_update_ha_state()
+
+        self._connection_listener = handle_connection_change
+        self._hub.add_connection_listener(handle_connection_change)
+
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Stop listening for hub connection changes."""
+        if self._connection_listener is not None:
+            self._hub.remove_connection_listener(self._connection_listener)
+            self._connection_listener = None
+        await super().async_will_remove_from_hass()
+
+    @property
+    @override
+    def extra_state_attributes(self) -> dict[str, str | bool] | None:
+        """Return hub metadata that was previously in the legacy hub state."""
+        return {
+            CONF_ID: f"{self._hub.host}::{self._hub.app_id}",
+            CONF_HOST: self._hub.host,
+            ATTR_HIDDEN: True,
+            CONF_TEMPERATURE_UNIT: self._hub.temperature_unit,
+            "connection_state": "connected" if self.is_on else "unavailable",
+        }
 
 
 class HubitatAccelerationSensor(HubitatBinarySensor):
@@ -271,6 +327,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Initialize binary sensor entities."""
+
+    hub = get_hub(hass, config_entry.entry_id)
+    hub_entities = [HubitatHubConnectionBinarySensor(hub=hub, device=hub.device)]
+    hub.add_entities(hub_entities)
+    async_add_entities(hub_entities)
 
     for attr in _SENSOR_ATTRS:
 

--- a/custom_components/hubitat/config_flow.py
+++ b/custom_components/hubitat/config_flow.py
@@ -72,7 +72,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-class HubitatConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore
+class HubitatConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Hubitat."""
 
     VERSION: int = 2
@@ -90,7 +90,7 @@ class HubitatConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore
     # TODO: remove the 'type: ignore' when were not falling back on
     # FlowResult
     @override
-    async def async_step_user(  # type: ignore
+    async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the user step."""

--- a/custom_components/hubitat/device.py
+++ b/custom_components/hubitat/device.py
@@ -108,7 +108,7 @@ class HubitatEntity(HubitatBase, UpdateableEntity, ABC):
     """An entity related to a Hubitat device."""
 
     hass: HomeAssistant
-    _listens_for_device_events: bool
+    _listens_for_device_events: bool = False
 
     def __init__(
         self,
@@ -148,13 +148,20 @@ class HubitatEntity(HubitatBase, UpdateableEntity, ABC):
             )
 
     def __del__(self):
-        if self._listens_for_device_events:
-            self._hub.remove_device_listener(self._device.id, self.handle_event)
-            _LOGGER.debug(
-                "Removed device listener for %s (%s)",
-                self._device.id,
-                self.__class__,
-            )
+        if not getattr(self, "_listens_for_device_events", False):
+            return
+
+        hub = getattr(self, "_hub", None)
+        device = getattr(self, "_device", None)
+        if hub is None or device is None:
+            return
+
+        hub.remove_device_listener(device.id, self.handle_event)
+        _LOGGER.debug(
+            "Removed device listener for %s (%s)",
+            device.id,
+            self.__class__,
+        )
 
     @property
     @override

--- a/custom_components/hubitat/device.py
+++ b/custom_components/hubitat/device.py
@@ -108,11 +108,13 @@ class HubitatEntity(HubitatBase, UpdateableEntity, ABC):
     """An entity related to a Hubitat device."""
 
     hass: HomeAssistant
+    _listens_for_device_events: bool
 
     def __init__(
         self,
         device_class: str | None = None,
         temp: bool = False,
+        listen_for_device_events: bool = True,
         **kwargs: Unpack[HubitatEntityArgs],
     ):
         """
@@ -124,6 +126,8 @@ class HubitatEntity(HubitatBase, UpdateableEntity, ABC):
             The device class for this entity; default is None.
         temp : bool
             If true, this is a temporary entity; default is False
+        listen_for_device_events : bool
+            If true, register a Hubitat device event listener.
         """
         HubitatBase.__init__(self, **kwargs)
         UpdateableEntity.__init__(self)
@@ -134,7 +138,8 @@ class HubitatEntity(HubitatBase, UpdateableEntity, ABC):
         self._attr_device_info: device_registry.DeviceInfo | None = get_device_info(
             self._hub, self._device
         )
-        if not temp:
+        self._listens_for_device_events = listen_for_device_events and not temp
+        if self._listens_for_device_events:
             self._hub.add_device_listener(self._device.id, self.handle_event)
             _LOGGER.debug(
                 "Added device listener for %s (%s)",
@@ -143,12 +148,13 @@ class HubitatEntity(HubitatBase, UpdateableEntity, ABC):
             )
 
     def __del__(self):
-        self._hub.remove_device_listener(self._device.id, self.handle_event)
-        _LOGGER.debug(
-            "Removed device listener for %s (%s)",
-            self._device.id,
-            self.__class__,
-        )
+        if self._listens_for_device_events:
+            self._hub.remove_device_listener(self._device.id, self.handle_event)
+            _LOGGER.debug(
+                "Removed device listener for %s (%s)",
+                self._device.id,
+                self.__class__,
+            )
 
     @property
     @override

--- a/custom_components/hubitat/fan.py
+++ b/custom_components/hubitat/fan.py
@@ -44,7 +44,7 @@ class HubitatFan(FanEntity, HubitatEntity):
         # HomeAssistant
         if "TURN_ON" in FanEntityFeature.__members__:
             self._attr_supported_features |= (
-                FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF  # type: ignore
+                FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
             )
             self._enable_turn_on_off_backwards_compatibility: bool = False
 
@@ -141,7 +141,7 @@ class HubitatFan(FanEntity, HubitatEntity):
         self,
         percentage: int | None = None,
         preset_mode: str | None = None,
-        **kwargs: Any,  # pyright: ignore[reportAny]
+        **kwargs: Any,
     ) -> None:
         """Turn on the switch."""
         _LOGGER.debug(
@@ -160,7 +160,7 @@ class HubitatFan(FanEntity, HubitatEntity):
             await self.send_command(DeviceCommand.SET_SPEED, DeviceState.ON)
 
     @override
-    async def async_turn_off(self, **kwargs: Any) -> None:  # pyright: ignore[reportAny]
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         _LOGGER.debug("Turning off %s", self.name)
         if DeviceCapability.SWITCH in self._device.capabilities:

--- a/custom_components/hubitat/hub.py
+++ b/custom_components/hubitat/hub.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.device_registry import DeviceEntry
 
 try:
     from homeassistant.helpers.discovery_flow import (
-        DiscoveryKey,  # pyright: ignore[reportAssignmentType]
+        DiscoveryKey,
     )
 except Exception:
 
@@ -1041,8 +1041,8 @@ if TYPE_CHECKING:
         title="Hubitat",
         data={},
         source="",
-        minor_version=0,  # type: ignore
-        discovery_keys=test_discovery_keys,  # pyright: ignore[reportArgumentType]
+        minor_version=0,
+        discovery_keys=test_discovery_keys,
         options=None,
         unique_id=None,
         subentries_data=None,

--- a/custom_components/hubitat/hub.py
+++ b/custom_components/hubitat/hub.py
@@ -404,11 +404,15 @@ class Hub(HasId):
 
         # setup proxy Device representing the hub that can be used for linked
         # entities
+        hub_device_id = cast(str | None, entry.data.get(H_CONF_HUB_ID))
+        if hub_device_id is None:
+            hub_device_id = get_hub_short_id(hubitat_hub)
         device = Device(
             {
-                "id": get_hub_short_id(hubitat_hub),
+                "id": hub_device_id,
                 "name": HUB_DEVICE_NAME,
                 "label": HUB_DEVICE_NAME,
+                "type": HUB_DEVICE_NAME,
                 "model": "Cx",
                 "manufacturer": HUB_NAME,
                 "attributes": [
@@ -553,11 +557,15 @@ class Hub(HasId):
         )
 
         # Create a placeholder device for the hub
+        hub_device_id = cast(str | None, entry.data.get(H_CONF_HUB_ID))
+        if hub_device_id is None:
+            hub_device_id = get_hub_short_id(hubitat_hub)
         device = Device(
             {
-                "id": "unknown",
+                "id": hub_device_id,
                 "name": HUB_DEVICE_NAME,
                 "label": HUB_DEVICE_NAME,
+                "type": HUB_DEVICE_NAME,
                 "model": "Cx",
                 "manufacturer": HUB_NAME,
                 "attributes": [],
@@ -595,9 +603,10 @@ class Hub(HasId):
             # Update the device with hub info
             self.device = Device(
                 {
-                    "id": get_hub_short_id(self._hub),
+                    "id": self.id,
                     "name": HUB_DEVICE_NAME,
                     "label": HUB_DEVICE_NAME,
+                    "type": HUB_DEVICE_NAME,
                     "model": "Cx",
                     "manufacturer": HUB_NAME,
                     "attributes": [

--- a/custom_components/hubitat/hub.py
+++ b/custom_components/hubitat/hub.py
@@ -44,6 +44,7 @@ from .const import (
     PLATFORMS,
     TEMP_F,
     TRIGGER_CAPABILITIES,
+    Platform,
 )
 from .hubitatmaker import (
     Device,
@@ -94,7 +95,7 @@ class Hub(HasId):
     _is_connected: bool
     _connection_listeners: list[ConnectionListener]
     _retry_task_unsub: CALLBACK_TYPE | None
-    _platforms_setup: bool
+    _setup_platforms: set[Platform]
 
     def __init__(
         self,
@@ -138,7 +139,7 @@ class Hub(HasId):
         self._is_connected = False
         self._connection_listeners = []
         self._retry_task_unsub = None
-        self._platforms_setup = False
+        self._setup_platforms = set()
 
     @property
     def app_id(self) -> str:
@@ -275,6 +276,16 @@ class Hub(HasId):
     def add_event_emitters(self, emitters: list[M]) -> None:
         """Add event emitters to this hub."""
         self.event_emitters.extend(emitters)
+
+    def mark_platforms_setup(self, platforms: tuple[Platform, ...]) -> None:
+        """Record that the listed platforms have been set up."""
+        self._setup_platforms.update(platforms)
+
+    def get_unsetup_platforms(
+        self, platforms: tuple[Platform, ...] = PLATFORMS
+    ) -> tuple[Platform, ...]:
+        """Return platforms that have not been set up yet."""
+        return tuple(p for p in platforms if p not in self._setup_platforms)
 
     def remove_device_listeners(self, device_id: str) -> None:
         """Remove all listeners for a specific device."""
@@ -439,6 +450,7 @@ class Hub(HasId):
 
         # Initialize entities
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+        hub.mark_platforms_setup(PLATFORMS)
 
         _LOGGER.debug("Registered platforms")
 
@@ -616,12 +628,13 @@ class Hub(HasId):
             # Migrate entity unique IDs from old token-hash format to new hub-id format
             _migrate_entity_unique_ids(self.hass, self.id, self.token)
 
-            # Initialize entities (only once - this is not idempotent)
-            if not self._platforms_setup:
+            # Initialize entities only for platforms that are not set up yet.
+            platforms_to_setup = self.get_unsetup_platforms()
+            if len(platforms_to_setup) > 0:
                 await self.hass.config_entries.async_forward_entry_setups(
-                    self.config_entry, PLATFORMS
+                    self.config_entry, platforms_to_setup
                 )
-                self._platforms_setup = True
+                self.mark_platforms_setup(platforms_to_setup)
 
             _LOGGER.debug("Registered platforms")
 

--- a/custom_components/hubitat/hub.py
+++ b/custom_components/hubitat/hub.py
@@ -270,8 +270,14 @@ class Hub(HasId):
             return
 
         self._is_connected = connected
-        for listener in self._connection_listeners:
-            listener(connected)
+        for listener in self._connection_listeners.copy():
+            try:
+                listener(connected)
+            except Exception:
+                _LOGGER.exception(
+                    "Error notifying connection listener for hub %s",
+                    self.id,
+                )
 
     def add_event_emitters(self, emitters: list[M]) -> None:
         """Add event emitters to this hub."""

--- a/custom_components/hubitat/hub.py
+++ b/custom_components/hubitat/hub.py
@@ -9,10 +9,8 @@ from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast, override
 from custom_components.hubitat.hubitatmaker.const import DeviceAttribute
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_HIDDEN,
     CONF_ACCESS_TOKEN,
     CONF_HOST,
-    CONF_ID,
     CONF_TEMPERATURE_UNIT,
     UnitOfTemperature,
 )
@@ -64,6 +62,7 @@ from .util import (
 _LOGGER = getLogger(__name__)
 
 Listener = Callable[[Event], None]
+ConnectionListener = Callable[[bool], None]
 
 HUB_DEVICE_NAME = "Hub"
 HUB_NAME = "Hubitat Elevation"
@@ -93,6 +92,7 @@ class Hub(HasId):
     _device_listeners: dict[str, list[Listener]]
     _hub: HubitatHub
     _is_connected: bool
+    _connection_listeners: list[ConnectionListener]
     _retry_task_unsub: CALLBACK_TYPE | None
     _platforms_setup: bool
 
@@ -136,6 +136,7 @@ class Hub(HasId):
         self._hub = hub
         self.device = device
         self._is_connected = False
+        self._connection_listeners = []
         self._retry_task_unsub = None
         self._platforms_setup = False
 
@@ -253,6 +254,24 @@ class Hub(HasId):
         """Add entities to this hub."""
         self.entities.extend(entities)
 
+    def add_connection_listener(self, listener: ConnectionListener) -> None:
+        """Add a listener for hub connection status changes."""
+        self._connection_listeners.append(listener)
+
+    def remove_connection_listener(self, listener: ConnectionListener) -> None:
+        """Remove a connection status listener."""
+        if listener in self._connection_listeners:
+            self._connection_listeners.remove(listener)
+
+    def set_connected(self, connected: bool) -> None:
+        """Set the connection status and notify listeners on change."""
+        if self._is_connected == connected:
+            return
+
+        self._is_connected = connected
+        for listener in self._connection_listeners:
+            listener(connected)
+
     def add_event_emitters(self, emitters: list[M]) -> None:
         """Add event emitters to this hub."""
         self.event_emitters.extend(emitters)
@@ -283,6 +302,7 @@ class Hub(HasId):
         """Stop the hub."""
         if self._hub:
             self._hub.stop()
+        self.set_connected(False)
         self._device_listeners = {}
         self._hub_device_listeners = []
 
@@ -304,16 +324,6 @@ class Hub(HasId):
 
         # Cancel retry task if it's still running
         self.cancel_retry_task()
-
-    def get_state_attributes(self) -> dict[str, Any]:
-        """Get the state attributes for the hub entity."""
-        attrs = {
-            CONF_ID: f"{self._hub.host}::{self._hub.app_id}",
-            CONF_HOST: self.host,
-            ATTR_HIDDEN: True,
-            CONF_TEMPERATURE_UNIT: self.temperature_unit,
-        }
-        return attrs
 
     @staticmethod
     async def create(hass: HomeAssistant, entry: ConfigEntry, index: int) -> "Hub":
@@ -408,7 +418,7 @@ class Hub(HasId):
         )
 
         hub = Hub(hass, entry, index, hubitat_hub, device)
-        hub._is_connected = True
+        hub.set_connected(True)
         domain_data = get_domain_data(hass)
         domain_data[entry.entry_id] = hub
 
@@ -438,13 +448,6 @@ class Hub(HasId):
         )
         if should_update_rooms:
             _update_device_rooms(hub, hass)
-
-        # Create an entity for the Hubitat hub with basic hub information
-        hass.states.async_set(
-            hub.entity_id,
-            "connected",
-            hub.get_state_attributes(),
-        )
 
         if hub.mode_supported:
 
@@ -552,16 +555,9 @@ class Hub(HasId):
         )
 
         hub = Hub(hass, entry, index, hubitat_hub, device)
-        hub._is_connected = False
+        hub.set_connected(False)
         domain_data = get_domain_data(hass)
         domain_data[entry.entry_id] = hub
-
-        # Create an entity for the Hubitat hub in unavailable state
-        hass.states.async_set(
-            hub.entity_id,
-            "unavailable",
-            hub.get_state_attributes(),
-        )
 
         return hub
 
@@ -666,7 +662,7 @@ class Hub(HasId):
                         DeviceAttribute.HSM_STATUS, self.hsm_status, None
                     )
 
-            self._is_connected = True
+            self.set_connected(True)
             _LOGGER.debug("Hub connection complete")
 
         except Exception:
@@ -681,6 +677,7 @@ class Hub(HasId):
             # Clear mode and HSM listeners
             self._hub.remove_mode_listeners()
             self._hub.remove_hsm_status_listeners()
+            self.set_connected(False)
 
             raise
 
@@ -770,12 +767,6 @@ class Hub(HasId):
             for entity in hub.entities:
                 entity.load_state()
             _LOGGER.debug("Set temperature units to %s", temp_unit)
-
-        hass.states.async_set(
-            hub.entity_id,
-            "connected",
-            {CONF_HOST: hub.host, CONF_TEMPERATURE_UNIT: hub.temperature_unit},
-        )
 
     async def check_config(self) -> None:
         """Verify that the hub is accessible."""

--- a/custom_components/hubitat/manifest.json
+++ b/custom_components/hubitat/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../manifest-schema.json",
-  "version": "0.10.2-pre0",
+  "version": "0.10.2rc0",
   "domain": "hubitat",
   "name": "Hubitat",
   "config_flow": true,

--- a/custom_components/hubitat/manifest.json
+++ b/custom_components/hubitat/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../manifest-schema.json",
-  "version": "0.10.1",
+  "version": "0.10.2-pre0",
   "domain": "hubitat",
   "name": "Hubitat",
   "config_flow": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hubitat"
-version = "0.10.2-pre0"
+version = "0.10.2rc0"
 description = "A Hubitat integration for Home Assistant"
 authors = [{ name = "Jason Cheatham", email = "jason@jasoncheatham.com" }]
 requires-python = ">=3.13.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ testpaths = ["tests"]
 filterwarnings = [
     "ignore::DeprecationWarning:pkg_resources",
     "ignore:Inheritance class HomeAssistantApplication:DeprecationWarning",
+    "ignore:.*asyncio\\.iscoroutinefunction.*:DeprecationWarning:litellm\\.litellm_core_utils\\.logging_utils",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hubitat"
-version = "0.10.1"
+version = "0.10.2-pre0"
 description = "A Hubitat integration for Home Assistant"
 authors = [{ name = "Jason Cheatham", email = "jason@jasoncheatham.com" }]
 requires-python = ">=3.13.2"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -157,6 +157,7 @@ def test_hub_connection_binary_sensor_has_unique_id():
     assert sensor.name == "Hub Status"
     assert sensor.is_on is True
     assert sensor.device_class == BinarySensorDeviceClass.CONNECTIVITY
+    hub.add_device_listener.assert_not_called()
     assert sensor.extra_state_attributes == {
         "id": "192.168.1.10::123",
         "host": "192.168.1.10",

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -167,6 +167,12 @@ def test_hub_connection_binary_sensor_has_unique_id():
     }
 
 
+def test_hub_status_del_safe_when_uninitialized():
+    """__del__ should be safe for partially initialized entities."""
+    sensor = HubitatHubConnectionBinarySensor.__new__(HubitatHubConnectionBinarySensor)
+    sensor.__del__()
+
+
 @pytest.mark.asyncio
 async def test_binary_sensor_setup_offline_adds_connection_listener():
     """When hub starts offline, binary sensor setup listens for reconnect."""

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -191,6 +191,8 @@ def test_hub_connection_binary_sensor_disconnected_state_attribute():
 def test_hub_status_del_safe_when_uninitialized():
     """__del__ should be safe for partially initialized entities."""
     sensor = HubitatHubConnectionBinarySensor.__new__(HubitatHubConnectionBinarySensor)
+    # __del__ is called explicitly to ensure the cleanup path is exercised in
+    # the test
     sensor.__del__()
 
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -167,6 +167,27 @@ def test_hub_connection_binary_sensor_has_unique_id():
     }
 
 
+def test_hub_connection_binary_sensor_disconnected_state_attribute():
+    """Disconnected hub status should use a non-HA-state string."""
+    hub = Mock()
+    hub.configure_mock(
+        id="hub12345",
+        is_connected=False,
+        host="192.168.1.10",
+        app_id="123",
+        temperature_unit="F",
+        add_device_listener=Mock(),
+        add_connection_listener=Mock(),
+    )
+
+    device = Mock()
+    device.configure_mock(id="hub12345", name="Hub", label="Hub", attributes={})
+
+    sensor = HubitatHubConnectionBinarySensor(hub=hub, device=device)
+    assert sensor.extra_state_attributes is not None
+    assert sensor.extra_state_attributes["connection_state"] == "disconnected"
+
+
 def test_hub_status_del_safe_when_uninitialized():
     """__del__ should be safe for partially initialized entities."""
     sensor = HubitatHubConnectionBinarySensor.__new__(HubitatHubConnectionBinarySensor)

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,6 +1,8 @@
 # pyright: reportAny=false, reportPrivateUsage=false
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
+
+import pytest
 
 from custom_components.hubitat.binary_sensor import (
     HubitatAccelerationSensor,
@@ -19,6 +21,7 @@ from custom_components.hubitat.binary_sensor import (
     HubitatSoundSensor,
     HubitatTamperSensor,
     HubitatValveSensor,
+    async_setup_entry,
 )
 from custom_components.hubitat.hubitatmaker.const import DeviceAttribute
 from custom_components.hubitat.hubitatmaker.types import Attribute
@@ -161,6 +164,33 @@ def test_hub_connection_binary_sensor_has_unique_id():
         "temperature_unit": "F",
         "connection_state": "connected",
     }
+
+
+@pytest.mark.asyncio
+async def test_binary_sensor_setup_offline_adds_connection_listener():
+    """When hub starts offline, binary sensor setup listens for reconnect."""
+    hub = Mock()
+    hub.configure_mock(
+        id="hub12345",
+        is_connected=False,
+        host="192.168.1.10",
+        app_id="123",
+        temperature_unit="F",
+        device=Mock(id="hub12345", name="Hub", label="Hub", attributes={}),
+        devices={},
+        add_device_listener=Mock(),
+        add_connection_listener=Mock(),
+        add_entities=Mock(),
+    )
+
+    hass = Mock()
+    config_entry = Mock(entry_id="entry")
+    async_add_entities = Mock()
+
+    with patch("custom_components.hubitat.binary_sensor.get_hub", return_value=hub):
+        await async_setup_entry(hass, config_entry, async_add_entities)
+
+    hub.add_connection_listener.assert_called_once()
 
 
 def test_acceleration_sensor():

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -8,6 +8,7 @@ from custom_components.hubitat.binary_sensor import (
     HubitatContactSensor,
     HubitatCoSensor,
     HubitatHeatSensor,
+    HubitatHubConnectionBinarySensor,
     HubitatMoistureSensor,
     HubitatMotionSensor,
     HubitatNaturalGasSensor,
@@ -124,6 +125,42 @@ def test_binary_sensor_device_attrs():
     )
 
     assert sensor.device_attrs == (DeviceAttribute.MOTION,)
+
+
+def test_hub_connection_binary_sensor_has_unique_id():
+    """Test that hub connection sensor has a stable unique ID."""
+    hub = Mock()
+    hub.configure_mock(
+        id="hub12345",
+        is_connected=True,
+        host="192.168.1.10",
+        app_id="123",
+        temperature_unit="F",
+        add_device_listener=Mock(),
+        add_connection_listener=Mock(),
+    )
+
+    device = Mock()
+    device.configure_mock(
+        id="hub12345",
+        name="Hub",
+        label="Hub",
+        attributes={},
+    )
+
+    sensor = HubitatHubConnectionBinarySensor(hub=hub, device=device)
+
+    assert sensor.unique_id == "hub12345::binary_sensor::hub_status"
+    assert sensor.name == "Hub Status"
+    assert sensor.is_on is True
+    assert sensor.device_class == BinarySensorDeviceClass.CONNECTIVITY
+    assert sensor.extra_state_attributes == {
+        "id": "192.168.1.10::123",
+        "host": "192.168.1.10",
+        "hidden": True,
+        "temperature_unit": "F",
+        "connection_state": "connected",
+    }
 
 
 def test_acceleration_sensor():

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "hubitat"
-version = "0.10.1"
+version = "0.10.2rc0"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
Add a standard sensor representing hub connection status (and other status values) to replace the manually managed `hub.status` entity.